### PR TITLE
add new daExport scripts

### DIFF
--- a/exporting/legacy/ReadParams.vbs
+++ b/exporting/legacy/ReadParams.vbs
@@ -1,0 +1,30 @@
+' Function to read parameters from a file into a Dictionary object
+Function ReadParametersFromFile(filePath)
+    Dim fso, file, line, params, key, value
+    Set fso = CreateObject("Scripting.FileSystemObject")
+    Set params = CreateObject("Scripting.Dictionary")
+
+    ' Check if the file exists
+    If fso.FileExists(filePath) Then
+        Set file = fso.OpenTextFile(filePath, 1, False)
+
+        ' Read the file line by line
+        Do Until file.AtEndOfStream
+            line = file.ReadLine
+            ' Split each line into key and value
+            If InStr(line, "=") > 0 Then
+                key = Split(line, "=")(0)
+                value = Split(line, "=")(1)
+                ' Store them in the Dictionary object
+                params(key) = value
+            End If
+        Loop
+
+        file.Close
+    Else
+        WScript.Echo "Parameters file not found."
+    End If
+
+    ' Return the Dictionary object containing the parameters
+    Set ReadParametersFromFile = params
+End Function

--- a/exporting/legacy/daCalib.vbs
+++ b/exporting/legacy/daCalib.vbs
@@ -1,0 +1,45 @@
+' This script calibrates the raw data and generates the Mass Pos Chromatogram (MPC) for each analysis in the project
+
+' Include the ReadParams.vbs file, needs absolute path if run from dataanalysis
+ExecuteGlobal CreateObject("Scripting.FileSystemObject").OpenTextFile("ReadParams.vbs", 1).ReadAll()
+
+' Call the function to read parameters
+Dim paramsFilePath, params
+' needs absolute path if run from dataanalysis
+paramsFilePath = "parameters.txt"
+Set params = ReadParametersFromFile(paramsFilePath)
+
+' Activate the DataAnalysis application if it is not already active
+Set DA = GetObject("","BDal.DataAnalysis.Application")
+DA.Activate(0)
+
+' calibrate the raw data, and generate MPC afterwards
+Dim currentAnalysis
+
+For Each currentAnalysis in DA.Analyses:
+
+	currentAnalysis.Select  true
+
+    ' disable the TIC to speed up the process
+    for Each Chrom in currentAnalysis.Chromatograms:
+        Chrom.Enable false
+    Next
+
+	currentAnalysis.LoadMethod params("customMethod")
+
+	currentAnalysis.ApplyLockMassCalibration true
+
+	Dim MPC
+
+	Set MPC = CreateObject("DataAnalysis.MassPosChromatogramDefinition")
+
+	MPC.Range=params("MPCmass")
+
+	MPC.WidthLeft=0.005
+
+	MPC.WidthRight=0.005
+
+	MPC.AbsoluteDeviation=False
+
+	currentAnalysis.Chromatograms.AddChromatogram MPC
+Next

--- a/exporting/legacy/daExport.vbs
+++ b/exporting/legacy/daExport.vbs
@@ -1,0 +1,71 @@
+' the modified script to export mass list to a text file
+
+' Include the ReadParams.vbs file, needs absolute path if run from dataanalysis
+ExecuteGlobal CreateObject("Scripting.FileSystemObject").OpenTextFile("ReadParams.vbs", 1).ReadAll()
+
+' Call the function to read parameters
+Dim paramsFilePath, params
+' needs absolute path if run from dataanalysis
+paramsFilePath = "parameters.txt"
+Set params = ReadParametersFromFile(paramsFilePath)
+
+' Activate the DataAnalysis application if it is not already active
+Set DA = GetObject("","BDal.DataAnalysis.Application")
+DA.Activate(0)
+
+mz_start = params("Q1mass") - params("Width")
+mz_end = params("Q1mass") + params("Width")
+const spec_start = 1
+
+Set DA = GetObject("","BDal.DataAnalysis.Application")
+DA.Activate(0)
+
+For Each currentAnalysis in Analyses:
+
+    For SpecCounter = currentAnalysis.Spectra.Count to 1 Step -1  ' deletes all previously generated spectra
+        currentAnalysis.Spectra.Delete SpecCounter
+    Next
+
+    spec_end = currentAnalysis.Chromatograms.Item(1).Size
+
+    Dim fso, logfile, line, buffer, count
+    Dim spec, peak, var
+    Dim specIndex
+
+    buffer = "" ' Use a buffer to accumulate lines before writing
+
+    For specIndex = spec_start To spec_end
+        currentAnalysis.Spectra.Add specIndex, daProfileOnly
+        currentAnalysis.Spectra(currentAnalysis.Spectra.Count).MassListFind mz_start, mz_end
+
+        Set spec = currentAnalysis.spectra(1)
+        For Each var In spec.Variables
+            If var.Name = "Spot Number" Then
+                buffer = buffer & var.Value
+                Exit For ' Exit once the spot number is found
+            End If
+        Next
+
+        line = ""
+        count = 0
+        For Each peak In spec.MSPeakList
+            ' Combine conditions to reduce redundancy
+            If peak.m_over_z > mz_start And peak.m_over_z < mz_end Then
+                count = count + 1
+                line = line & ";" & peak.m_over_z & ";" & peak.Intensity & ";" & peak.SignaltoNoise
+            End If
+        Next
+
+        buffer = buffer & ";" & count & line & vbCrLf ' Append newline for each spectrum
+
+        currentAnalysis.Spectra.Delete currentAnalysis.Spectra.Count ' Remove spectrum from compound list
+
+    Next
+
+    Set fso = CreateObject("Scripting.FileSystemObject")
+    savePath = params("ExportDataPath") & "\" & currentAnalysis.Name & ".txt"
+    Set logfile = fso.OpenTextFile(savePath, 2, True)
+    logfile.Write buffer ' Write the accumulated data to file in one operation
+    logfile.Close
+
+Next

--- a/exporting/legacy/openall.vbs
+++ b/exporting/legacy/openall.vbs
@@ -1,0 +1,33 @@
+' This script loops through the raw data and open all data files
+
+' Include the ReadParams.vbs file
+ExecuteGlobal CreateObject("Scripting.FileSystemObject").OpenTextFile("ReadParams.vbs", 1).ReadAll()
+
+' Call the function to read parameters
+Dim paramsFilePath, params
+paramsFilePath = "parameters.txt"
+Set params = ReadParametersFromFile(paramsFilePath)
+
+' Activate the DataAnalysis application if it is not already active
+Set DA = GetObject("","BDal.DataAnalysis.Application")
+DA.Activate(0)
+
+' Create a FileSystemObject to search the raw data folder
+Dim fso
+Set fso = CreateObject("Scripting.FileSystemObject")
+SearchFolders params("RawDataPath")
+
+Sub SearchFolders(ByVal folderPath)
+    Dim folder, subFolder
+    Set folder = fso.GetFolder(folderPath)
+
+    ' Check each subfolder in the current folder
+    For Each subFolder In folder.SubFolders
+        ' Check if the folder name includes Q1mass and ends with ".d"
+        If InStr(subFolder.Name, CStr(params("Q1mass"))) > 0 And Right(subFolder.Name, 2) = ".d" Then
+            DA.Analyses.Open(subFolder.Path)
+        End If
+        ' Recursively search this subfolder for more folders
+        SearchFolders subFolder.Path
+    Next
+End Sub

--- a/exporting/legacy/parameters.txt
+++ b/exporting/legacy/parameters.txt
@@ -1,0 +1,6 @@
+Q1mass=1320
+Width=20
+MPCmass=1324.3046
+customMethod=D:/Methods/DataAnalysis FTMS SNR0 calibCren.m
+RawDataPath="D:/SBB/raw_data"
+ExportDataPath="D:/SBB/exported_data"


### PR DESCRIPTION
add new daExport scripts in the legacy module:

modified the classic daExport script for a less-effort while more-transparent data exporting process under the `legacy` module. It's particularly suitable for long cores with lots of data files. There are there parts: 
- `openall.vbs` opens all the data files (e.g., alkenone window measurement from all slides); 
-  `daCalib`  calibrate all the data files in DataAnalysis and generate the chosen MPC after calibration, so one can have a good overview of the calibration; 
-  `daExport` batch exports all the mass lists from DataAnalysis like the classic daExport script. 
All parameters need to be set are in a `parameters.txt` file. 